### PR TITLE
Fixing the DriverRepoPackage to consider the metadata file as a file

### DIFF
--- a/articlegenerator/extract.py
+++ b/articlegenerator/extract.py
@@ -48,8 +48,12 @@ class DriverRepoDataSource(ArticleDataSource):
         # Get kernel version
         data_rec['kernel_version'] = drp.get_kernel_version()
 
-        # Get metadata md5
-        data_rec['metadata_md5'] = drp.get_metadata_md5()
+        metadata = drp.get_metadata_file()
+        # Get metadata file
+        data_rec['metadata_file'] = {
+                                      'filename': metadata.get_filename(),
+                                      'data': metadata.get_contents(),
+                                    }
 
         # Get RPM information
         rpm_data = []

--- a/articlegenerator/tests/extract_tests.py
+++ b/articlegenerator/tests/extract_tests.py
@@ -53,7 +53,13 @@ class DriverRepoDataSourceTests(unittest.TestCase):
                                 'filesize': '59693',
                                },
                         'ctx': 'CTXTestNumber',
-                        'metadata_md5': 'metadata_md5',
+                        'metadata_file': {
+                                           'filename': 'test.metadata.md5',
+                                           'fileloc': '/tmp/test.metadata.md5',
+                                           'data': '23523582358235235',
+                                           'md5': 'asdfasdfasdf',
+                                           'filesize': '124124',
+                                         },
                         'driver_rpms': [
                                         {
                                           'filename':'test-rpm-1.rpm',
@@ -111,7 +117,8 @@ class DriverRepoDataSourceTests(unittest.TestCase):
         self.assertEqual(data['zip']['md5'], mock_data['zip']['md5'])
 
         self.assertEqual(data['kernel_version'], mock_data['kernel_version'])
-        self.assertEqual(data['metadata_md5'], mock_data['metadata_md5'])
+        self.assertEqual(data['metadata_file']['filename'], mock_data['metadata_file']['filename'])
+        self.assertEqual(data['metadata_file']['data'], mock_data['metadata_file']['data'])
 
         #Verify RPM data
         assert len(mock_data['driver_rpms']) + \

--- a/driverfiles/mock_models.py
+++ b/driverfiles/mock_models.py
@@ -65,8 +65,8 @@ class MockDriverRepoPackage(DriverRepoPackage):
     def get_ctx(self):
         return self.mock_rec['ctx']   
     
-    def get_metadata_md5(self):
-        return self.mock_rec['metadata_md5']
+    def get_metadata_file(self):
+        return MockBinaryFile(self.mock_rec['metadata_file'])
 
     def get_rpms(self):
         driver_rpms = []

--- a/driverfiles/models.py
+++ b/driverfiles/models.py
@@ -156,8 +156,8 @@ class DriverRepoPackage(object):
     def get_ctx(self):
         return self.attrs.group('ctx')
 
-    def get_metadata_md5(self):
-        return self.metadata_file.get_contents()
+    def get_metadata_file(self):
+        return self.metadata_file
 
     def get_rpms(self):
         driver_rpms = []

--- a/driverfiles/tests/file_tests.py
+++ b/driverfiles/tests/file_tests.py
@@ -166,7 +166,7 @@ class TestDriverRepoPackage(unittest.TestCase):
     
     def test_get_metadata_md5(self):
         drp = models.DriverRepoPackage(self.directory)
-        metadata_md5 = drp.get_metadata_md5()
+        metadata_md5 = drp.get_metadata_file().get_contents()
         assert_equal(self.sample_data['metadata_md5'], metadata_md5)
         
     def test_verify_driver_versions(self):


### PR DESCRIPTION
For some reason the metadata md5 was treated as a separate attribute of the repository, rather than just considering it to be a binary file. This is important as a consumer may wish to know what the filename is for the metadata file.

Signed-off-by: Rob Dobson rob@rdobson.co.uk
